### PR TITLE
Template files 

### DIFF
--- a/ferretz/ferretz.py
+++ b/ferretz/ferretz.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from pathlib import Path
 from random import choice
 
@@ -21,7 +23,6 @@ def greet_user():
     print('')
 
 
-
 def create_directory_structure(package_name, author, email, target_dir):
     print(f"{BLUE}🦡 Creating your lair... Ahem, I mean your package directory! 📦{RESET}")
 
@@ -36,7 +37,7 @@ def create_directory_structure(package_name, author, email, target_dir):
         'image_conversion.py', 'image_processing.py', '__init__.py',
         'input_validation.py', f"{package_name}.py", 'resources.py'
     ]
-    
+
     module_descriptions = {
         'constants.py': 'This module holds all the constant values.',
         'display.py': 'This module is responsible for displaying information.',
@@ -52,11 +53,21 @@ def create_directory_structure(package_name, author, email, target_dir):
 
     summary = []
 
+    ferretz_directory = os.path.dirname(os.path.abspath(__file__))
+    template_modules_directory = os.path.join(ferretz_directory, "template_modules")
+    existing_module_templates = os.listdir(template_modules_directory)
+    summary.append(f"Existing modules: {existing_module_templates} at {template_modules_directory}")
+
     for module in modules:
-        module_path = package_dir / module
-        description = module_descriptions.get(module, 'No description available.')
-        with open(module_path, 'w') as f:
-            preamble = f"""#!/usr/bin/env python3
+        module_path = os.path.join(package_dir, module)
+        if module in existing_module_templates:
+            shutil.copy(os.path.join(template_modules_directory, module), module_path)
+            summary.append(f"Copied: {module_path} (from template repository)")
+        else:
+            description = module_descriptions.get(module, 'No description available.')
+            with open(module_path, 'w') as f:
+                preamble = f"""#!/usr/bin/env python3
+            
 # -*- coding: utf-8 -*-
 
 '''
@@ -70,8 +81,8 @@ def create_directory_structure(package_name, author, email, target_dir):
 
 # Your code here
 """
-            f.write(preamble)
-        summary.append(f"Created: {module_path}")
+                f.write(preamble)
+            summary.append(f"Created: {module_path}")
 
     with open(setup_py, 'w') as f:
         content = f"""from setuptools import setup, find_packages
@@ -141,13 +152,16 @@ def create_new_package():
 
 def main():
     greet_user()
-    action = input(f"{BLUE}🦡 What's on the agenda today, boss? ('new' to create a new package) 🎬{RESET} ")
+    action = input(f"{BLUE}🦡 What's on the agenda today, boss? ('new' to create a new package, 'exit' to ...exit.) 🎬{RESET} ")
 
     if action.lower() == 'new':
         create_new_package()
+    elif action.lower() == 'exit':
+        print(f"{BLUE}🦡 Goodbye! 👋{RESET} ")
+        return
     else:
         print(f"{RED}🦡 Aww, shucks! I don't know that command. 🚫{RESET} ")
 
+
 if __name__ == "__main__":
     main()
-

--- a/ferretz/ferretz.py
+++ b/ferretz/ferretz.py
@@ -8,6 +8,7 @@ RED = '\033[91m'
 GREEN = '\033[92m'
 BLUE = '\033[38;5;141m'
 RESET = '\033[0m'
+TEMPLATE_EXTENSION = ".tmpl"
 
 
 def greet_user():
@@ -55,13 +56,15 @@ def create_directory_structure(package_name, author, email, target_dir):
 
     ferretz_directory = os.path.dirname(os.path.abspath(__file__))
     template_modules_directory = os.path.join(ferretz_directory, "template_modules")
-    existing_module_templates = os.listdir(template_modules_directory)
+    existing_module_templates = [file for file in os.listdir(template_modules_directory) if file.endswith(TEMPLATE_EXTENSION)]
     summary.append(f"Existing modules: {existing_module_templates} at {template_modules_directory}")
 
     for module in modules:
         module_path = os.path.join(package_dir, module)
-        if module in existing_module_templates:
-            shutil.copy(os.path.join(template_modules_directory, module), module_path)
+
+        # Checks if a template file exists
+        if f"{module}{TEMPLATE_EXTENSION}" in existing_module_templates:
+            shutil.copy(os.path.join(template_modules_directory, f"{module}{TEMPLATE_EXTENSION}"), module_path)
             summary.append(f"Copied: {module_path} (from template repository)")
         else:
             description = module_descriptions.get(module, 'No description available.')

--- a/ferretz/template_modules/constants.py.tmpl
+++ b/ferretz/template_modules/constants.py.tmpl
@@ -1,0 +1,5 @@
+# ANSI Escape Codes for color output
+RED = '\033[91m'
+GREEN = '\033[92m'
+BLUE = '\033[38;5;141m'
+RESET = '\033[0m'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ferretz',
-    version='0.1',
+    version='0.2',
     description='A Python package to create "enhance.pet" compliant package folder structures',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
@@ -11,7 +11,8 @@ setup(
     author_email='lalith.shiyamsundar@meduniwien.ac.at',
     url='https://github.com/LalithShiyam/ferretz',  # Replace with your GitHub URL
     license='MIT',  # Replace with your license
-    packages=find_packages(),
+    packages=find_packages(exclude=['template_modules']),
+    package_data={'ferretz': ['template_modules/*.py']},
     entry_points={
         'console_scripts': ['ferretz=ferretz.ferretz:main'],
     },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # setup.py for ferretz
 from setuptools import setup, find_packages
-
 setup(
     name='ferretz',
     version='0.2',
@@ -11,8 +10,9 @@ setup(
     author_email='lalith.shiyamsundar@meduniwien.ac.at',
     url='https://github.com/LalithShiyam/ferretz',  # Replace with your GitHub URL
     license='MIT',  # Replace with your license
-    packages=find_packages(exclude=['template_modules']),
-    package_data={'ferretz': ['template_modules/*.py']},
+    packages=find_packages(),
+    package_data={'ferretz': ['template_modules/*.py.tmpl']},
+    include_package_data=True,
     entry_points={
         'console_scripts': ['ferretz=ferretz.ferretz:main'],
     },


### PR DESCRIPTION
Makes it possible to place template python files (`.py.tmpl`) in the `module_templates` folder. Upon creation of new packages, `ferretz` will first search for existing template file to copy before creating them from scratch. 

Also added the possibility to exit cleanly via `exit`.